### PR TITLE
Error type for from_env_ext function: update

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,9 @@ pub struct FromEnvError {
 pub enum FromEnvErrorKind {
     /// There is no environment variable that describes jobserver to inherit.
     NoEnvVar,
+    /// There is no jobserver in the environment variable.
+    /// Variables associated with Make can be used for passing data other than jobserver info.
+    NoJobserver,
     /// Cannot parse jobserver environment variable value, incorrect format.
     CannotParse,
     /// Cannot open path or name from the jobserver environment variable value.
@@ -32,6 +35,7 @@ impl FromEnvError {
     pub fn kind(&self) -> FromEnvErrorKind {
         match self.inner {
             FromEnvErrorInner::NoEnvVar => FromEnvErrorKind::NoEnvVar,
+            FromEnvErrorInner::NoJobserver => FromEnvErrorKind::NoJobserver,
             FromEnvErrorInner::CannotParse(_) => FromEnvErrorKind::CannotParse,
             FromEnvErrorInner::CannotOpenPath(..) => FromEnvErrorKind::CannotOpenPath,
             FromEnvErrorInner::CannotOpenFd(..) => FromEnvErrorKind::CannotOpenFd,
@@ -45,6 +49,7 @@ impl std::fmt::Display for FromEnvError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.inner {
             FromEnvErrorInner::NoEnvVar => write!(f, "there is no environment variable that describes jobserver to inherit"),
+            FromEnvErrorInner::NoJobserver => write!(f, "there is no `--jobserver-fds=` or `--jobserver-auth=` in the environment variable"),
             FromEnvErrorInner::CannotParse(s) => write!(f, "cannot parse jobserver environment variable value: {s}"),
             FromEnvErrorInner::CannotOpenPath(s, err) => write!(f, "cannot open path or name {s} from the jobserver environment variable value: {err}"),
             FromEnvErrorInner::CannotOpenFd(fd, err) => write!(f, "cannot open file descriptor {fd} from the jobserver environment variable value: {err}"),
@@ -70,6 +75,7 @@ impl std::error::Error for FromEnvError {
 #[derive(Debug)]
 pub(crate) enum FromEnvErrorInner {
     NoEnvVar,
+    NoJobserver,
     CannotParse(String),
     CannotOpenPath(String, std::io::Error),
     CannotOpenFd(RawFd, std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,12 +285,7 @@ impl Client {
             .find_map(|pos| pos)
         {
             Some((arg, pos)) => (arg, pos),
-            None => {
-                let err = FromEnvErrorInner::CannotParse(
-                    "expected `--jobserver-fds=` or `--jobserver-auth=`".to_string(),
-                );
-                return FromEnv::new_err(err, env, var_os);
-            }
+            None => return FromEnv::new_err(FromEnvErrorInner::NoJobserver, env, var_os),
         };
 
         let s = var[pos + arg.len()..].split(' ').next().unwrap();


### PR DESCRIPTION
Continue #51 implementation

It's [possible](https://www.gnu.org/software/make/manual/html_node/Options_002fRecursion.html) that env var exists but doesn't contain jobserver. We'd like to discern this situation from `CannotParse` error.