### PR TITLE
feat: Make `Client::from_env` safe to call for any number of times

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -446,10 +446,10 @@ unsafe fn fd_check(fd: c_int, check_pipe: bool) -> Result<(), FromEnvErrorInner>
 }
 
 fn clone_fd_and_set_cloexec(fd: c_int) -> Result<File, FromEnvErrorInner> {
-    // Safety: File is wrapped in `ManuallyDrop` to prevent closing on drop
-    // since we don't own the fd.
-    mem::ManuallyDrop::new(unsafe { File::from_raw_fd(fd) })
-        .try_clone()
+    // Safety: fd is a valid fd dand it remains open until returns
+    unsafe { BorrowedFd::borrow_raw(fd) }
+        .try_clone_to_owned()
+        .map(File::from)
         .map_err(|err| FromEnvErrorInner::CannotOpenFd(fd, err))
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -158,9 +158,10 @@ impl Client {
             }
         }
 
-        drop(set_cloexec(read, true));
-        drop(set_cloexec(write, true));
-        Ok(Some(Client::from_fds(read, write)))
+        Ok(Some(Client::Pipe {
+            read: clone_fd_and_set_cloexec(read)?,
+            write: clone_fd_and_set_cloexec(write)?,
+        }))
     }
 
     unsafe fn from_fds(read: c_int, write: c_int) -> Client {
@@ -442,6 +443,14 @@ unsafe fn fd_check(fd: c_int, check_pipe: bool) -> Result<(), FromEnvErrorInner>
     } else {
         fcntl_check(fd)
     }
+}
+
+fn clone_fd_and_set_cloexec(fd: c_int) -> Result<File, FromEnvErrorInner> {
+    // Safety: File is wrapped in `ManuallyDrop` to prevent closing on drop
+    // since we don't own the fd.
+    mem::ManuallyDrop::new(unsafe { File::from_raw_fd(fd) })
+        .try_clone()
+        .map_err(|err| FromEnvErrorInner::CannotOpenFd(fd, err))
 }
 
 fn set_cloexec(fd: c_int, set: bool) -> io::Result<()> {


### PR DESCRIPTION
So that it can be used in different crates without causing UB.

## Motivation

[`opencv-rust`](https://github.com/twistedfall/opencv-rust) uses `jobserver::Client::from_env` in its `build.rs` to parallelize generation of bindings, then call `cc::Build::compile` with features `cc/parallel` enabled it will also call `jobserver::Client::from_env` and creates a UB https://github.com/rust-lang/cc-rs/issues/844#issuecomment-1663960861

Workaround for this will require either wrapping `jobserver::Client` with `std::mem::ManuallyDrop`, or switching to my fork [`jobslot`](https://docs.rs/jobslot) which supports calling `Client::from_env` unlimited number of times.

This PR thus port the change to upstream so that any crate using `jobserver` can benefit from this and can stop worrying about UB caused by calling `Clieng::from_env` multiple times in different crates.