### PR TITLE
chore: set MSRV to 1.66 and edition to 2021

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,23 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, macos, windows]
-        include:
-          - build: stable
-            os: ubuntu-latest
-            rust: stable
-          - build: beta
-            os: ubuntu-latest
-            rust: beta
-          - build: nightly
-            os: ubuntu-latest
-            rust: nightly
-          - build: macos
-            os: macos-latest
-            rust: stable
-          - build: windows
-            os: windows-latest
-            rust: stable
+        rust: ["1.66", stable, beta, nightly]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ documentation = "https://docs.rs/jobserver"
 description = """
 An implementation of the GNU make jobserver for Rust
 """
-edition = "2018"
+edition = "2021"
+rust-version = "1.66"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.50"


### PR DESCRIPTION
Some new API were already used

* format arg capture (1.58)
* `std::os::fd` (1.66)

A bump is inevitably coming.