### PR TITLE
Add rust-version spec to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = """
 An implementation of the GNU make jobserver for Rust
 """
 edition = "2018"
+rust-version = "1.66"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.50"


### PR DESCRIPTION
The last version of the crate (0.1.27) started to trigger build failures with older rustc (1.59 in my case) due to usage of the API that were introduced in 1.66:

```
error[E0412]: cannot find type `RawFd` in `std::os::fd`
 --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.27/src/error.rs:2:27
  |
2 | type RawFd = std::os::fd::RawFd;
  |                           ^^^^^ not found in `std::os::fd`
  |
help: consider importing this type alias
  |
1 | use std::os::unix::prelude::RawFd;
  |

error[E0603]: module `fd` is private
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/jobserver-0.1.27/src/error.rs:2:23
    |
2   | type RawFd = std::os::fd::RawFd;
    |                       ^^ private module
    |
note: the module `fd` is defined here
```
The `std::os::fd` is only available since rust 1.66: https://doc.rust-lang.org/stable/std/os/fd/index.html

Adding the `rust-version` spec to `Cargo.toml` will make sure that cargo downloads a lower version that's compatible when doing a build. To make sure it works properly you'd also need to yank the 0.1.27 after releasing the fix.