### PR TITLE
Reduce MSRV to 1.63 with minor change in RawFd type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.60", stable, beta, nightly]
+        rust: ["1.63", stable, beta, nightly]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.66", stable, beta, nightly]
+        rust: ["1.60", stable, beta, nightly]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 An implementation of the GNU make jobserver for Rust
 """
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 An implementation of the GNU make jobserver for Rust
 """
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.60"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.50"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-type RawFd = std::os::fd::RawFd;
+type RawFd = std::os::unix::io::RawFd;
 #[cfg(not(unix))]
 type RawFd = std::convert::Infallible;
 


### PR DESCRIPTION
I noticed that a patch version increment has caused other crates MSRV values to change, such as the zstd crate: https://github.com/gyscos/zstd-rs/issues/253

This MR changes the RawFd type to one present in older versions of rust, so that the MSRV can be reduced to 1.63.

My understanding is that this type should be equivalent because it's gated against `#[cfg(unix)]`, and so the benefits of `std::os::fd::RawFd` also supporting WASM is negated. https://github.com/rust-lang/rust/issues/98699

In theory the MSRV of the crate library is 1.60, but there are dev-dependencies that require 1.63 which would break the MSRV testing workflow (rustix, required by tempfile). 

If we insist on keeping the usage of `std::os::fd::RawFd`, I can feed back to the zstd crate and ask them to bump their MSRV instead. Thank you!