### PR TITLE
fix: last `--jobserver-auth` wins 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,21 +614,39 @@ fn no_helper_deadlock() {
 #[test]
 fn test_find_jobserver_auth() {
     let cases = [
-        ("--jobserver-auth=auth-a --jobserver-auth=auth-b", "auth-b"),
-        ("--jobserver-auth=auth-b --jobserver-auth=auth-a", "auth-a"),
-        ("--jobserver-fds=fds-a --jobserver-fds=fds-b", "fds-b"),
-        ("--jobserver-fds=fds-b --jobserver-fds=fds-a", "fds-a"),
+        ("", None),
+        ("-j2", None),
+        ("-j2 --jobserver-auth=3,4", Some("3,4")),
+        ("--jobserver-auth=3,4 -j2", Some("3,4")),
+        ("--jobserver-auth=3,4", Some("3,4")),
+        ("--jobserver-auth=fifo:/myfifo", Some("fifo:/myfifo")),
+        ("--jobserver-auth=", Some("")),
+        ("--jobserver-auth", None),
+        ("--jobserver-fds=3,4", Some("3,4")),
+        ("--jobserver-fds=fifo:/myfifo", Some("fifo:/myfifo")),
+        ("--jobserver-fds=", Some("")),
+        ("--jobserver-fds", None),
+        (
+            "--jobserver-auth=auth-a --jobserver-auth=auth-b",
+            Some("auth-b"),
+        ),
+        (
+            "--jobserver-auth=auth-b --jobserver-auth=auth-a",
+            Some("auth-a"),
+        ),
+        ("--jobserver-fds=fds-a --jobserver-fds=fds-b", Some("fds-b")),
+        ("--jobserver-fds=fds-b --jobserver-fds=fds-a", Some("fds-a")),
         (
             "--jobserver-auth=auth-a --jobserver-fds=fds-a --jobserver-auth=auth-b",
-            "auth-b",
+            Some("auth-b"),
         ),
         (
             "--jobserver-fds=fds-a --jobserver-auth=auth-a --jobserver-fds=fds-b",
-            "auth-a",
+            Some("auth-a"),
         ),
     ];
     for (var, expected) in cases {
-        let actual = find_jobserver_auth(var).unwrap();
+        let actual = find_jobserver_auth(var);
         assert_eq!(
             actual, expected,
             "expect {expected:?}, got {actual:?}, input `{var:?}`"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,3 +595,28 @@ fn no_helper_deadlock() {
     let _y = x.clone();
     std::mem::drop(x.into_helper_thread(|_| {}).unwrap());
 }
+
+#[test]
+fn test_find_jobserver_auth() {
+    let cases = [
+        ("--jobserver-auth=auth-a --jobserver-auth=auth-b", "auth-a"),
+        ("--jobserver-auth=auth-b --jobserver-auth=auth-a", "auth-b"),
+        ("--jobserver-fds=fds-a --jobserver-fds=fds-b", "fds-a"),
+        ("--jobserver-fds=fds-b --jobserver-fds=fds-a", "fds-b"),
+        (
+            "--jobserver-auth=auth-a --jobserver-fds=fds-a --jobserver-auth=auth-b",
+            "fds-a",
+        ),
+        (
+            "--jobserver-fds=fds-a --jobserver-auth=auth-a --jobserver-fds=fds-b",
+            "fds-a",
+        ),
+    ];
+    for (var, expected) in cases {
+        let actual = find_jobserver_auth(var).unwrap();
+        assert_eq!(
+            actual, expected,
+            "expect {expected:?}, got {actual:?}, input `{var:?}`"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,11 +279,7 @@ impl Client {
             }
         };
 
-        let (arg, pos) = match ["--jobserver-fds=", "--jobserver-auth="]
-            .iter()
-            .map(|&arg| var.find(arg).map(|pos| (arg, pos)))
-            .find_map(|pos| pos)
-        {
+        let (arg, pos) = match find_jobserver_auth(var) {
             Some((arg, pos)) => (arg, pos),
             None => return FromEnv::new_err(FromEnvErrorInner::NoJobserver, env, var_os),
         };
@@ -586,6 +582,13 @@ impl HelperState {
     fn producer_done(&self) -> bool {
         self.lock().producer_done
     }
+}
+
+fn find_jobserver_auth(var: &str) -> Option<(&str, usize)> {
+    ["--jobserver-fds=", "--jobserver-auth="]
+        .iter()
+        .map(|&arg| var.find(arg).map(|pos| (arg, pos)))
+        .find_map(|pos| pos)
 }
 
 #[test]


### PR DESCRIPTION
From the GNU make manual[^1]:

> Be aware that the `MAKEFLAGS` variable may contain multiple
> instances of the `--jobserver-auth=` option.
> Only the last instance is relevant.

Hence this commit makes it so.

With this commit, `--jobserver-auth` also takes precedence over
`--jobserver-fds`, even when `--jobserver-fds` is the last instance
of these flags. This is made intentionally since `--jobserver-fds`
was an undocumented internal-only flag before `--jobserver-auth`
made public, according to this announcement[^2].

[^1]: https://www.gnu.org/software/make/manual/make.html#Job-Slots
[^2]: https://git.savannah.gnu.org/cgit/make.git/tree/NEWS?h=4.2#n31

fixes #66 