### PR TITLE
CI: Improve msrv checking and speedup CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
 
+    - run: cargo +stable update
+
     - uses: Swatinem/rust-cache@v2
 
     - run: cargo test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         rust: ["1.63", stable, beta, nightly]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
     steps:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)
       run: |
-        rustup update ${{ matrix.rust }} --no-self-update
+        rustup toolchain install ${{ matrix.rust }} --no-self-update --profile minimal
         rustup default ${{ matrix.rust }}
       shell: bash
 
@@ -93,8 +93,9 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)
       run: |
-        rustup update $MSRV --no-self-update
+        rustup toolchain install $MSRV --no-self-update --profile minimal
         rustup default $MSRV
+        rustup toolchain install nightly --no-self-update --profile minimal
       shell: bash
 
     - run: cargo +nightly update -Zminimal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,25 +17,34 @@ jobs:
 
     - run: cargo test
 
+    - name: Cache make compiled
+      if: ${{ !startsWith(matrix.os, 'windows') }}
+      id: cache-make
+      uses: actions/cache@v4
+      with:
+        path: /usr/local/bin/make
+        key: ${{ runner.os }}-make-4.4.1
+
     # Compile it from source (temporarily)
     - name: Make GNU Make from source
-      if: ${{ !startsWith(matrix.os, 'windows') }}
+      if: ${{ !startsWith(matrix.os, 'windows') }} && steps.cache-make.outputs.cache-hit != 'true'
       env:
         VERSION: "4.4.1"
       shell: bash
       run: |
-        wget -q "https://ftp.gnu.org/gnu/make/make-${VERSION}.tar.gz"
-        tar zxf "make-${VERSION}.tar.gz"
+        curl "https://ftp.gnu.org/gnu/make/make-${VERSION}.tar.gz" | tar xz
         pushd "make-${VERSION}"
         ./configure
-        make
+        make -j 4
         popd
-        cp -rp "make-${VERSION}/make" .
+        cp -p "make-${VERSION}/make" /usr/local/bin
+
     - name: Test against GNU Make from source
       if: ${{ !startsWith(matrix.os, 'windows') }}
       shell: bash
-      run:
-        MAKE="${PWD}/make" cargo test
+      run: cargo test
+      env:
+        MAKE: /usr/local/bin/make
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: CI
 on: [push, pull_request]
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
     # Compile it from source (temporarily)
     - name: Make GNU Make from source
-      if: ${{ !startsWith(matrix.os, 'windows') }} && steps.cache-make.outputs.cache-hit != 'true'
+      if: ${{ !startsWith(matrix.os, 'windows') && steps.cache-make.outputs.cache-hit != 'true' }}
       env:
         VERSION: "4.4.1"
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
         rustup toolchain install nightly --no-self-update --profile minimal
       shell: bash
 
-    - run: cargo +nightly update -Zminimal
+    - run: cargo +nightly update -Zminimal-versions
 
     - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,15 +10,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.63", stable, beta, nightly]
+        rust: [stable, beta, nightly]
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)
-      run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      run: |
+        rustup update ${{ matrix.rust }} --no-self-update
+        rustup default ${{ matrix.rust }}
       shell: bash
 
-    - run: cargo +stable update
+    - run: cargo update
 
     - uses: Swatinem/rust-cache@v2
 
@@ -79,3 +81,24 @@ jobs:
           git -c user.name='ci' -c user.email='ci' commit -m init
           git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+
+  msrv:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    env:
+      MSRV: 1.63
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust (rustup)
+      run: |
+        rustup update $MSRV --no-self-update
+        rustup default $MSRV
+      shell: bash
+
+    - run: cargo +nightly update -Zminimal
+
+    - uses: Swatinem/rust-cache@v2
+
+    - run: cargo check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
 
+    - uses: Swatinem/rust-cache@v2
+
     - run: cargo test
 
     - name: Cache make compiled


### PR DESCRIPTION
Improve msrv CI:
 - Run `cargo +nightly -Zminimal-versions update` before checking for msrv, to create a lockfile containing the minimal versions of dependencies
 - Run `cargo-check` to check for msrv (in a new job), running `cargo-test` would also pull in test dependencies and test code

This PR also speeds up the CI from 5m down to 1m (when make and dependencies are cached).