### PR TITLE
fix try_acquire for wasm target

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -48,10 +48,10 @@ impl Client {
     pub fn try_acquire(&self) -> io::Result<Option<Acquired>> {
         let mut lock = self.inner.count.lock().unwrap_or_else(|e| e.into_inner());
         if *lock == 0 {
-            None
+            Ok(None)
         } else {
             *lock -= 1;
-            Ok(Acquired(()))
+            Ok(Some(Acquired(())))
         }
     }
 


### PR DESCRIPTION
The wasm target's `Client::try_acquire` method doesn't compile because the return value doesn't match the method's signature. This PR fixes that by wrapping the return value in a `Result` which adheres to the method's signature.