### PR TITLE
CI: Support automatic publish to crates.io on tag creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish to crates.io
+        run: |
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
<https://github.com/rust-lang/infra-team/issues/117>

This would make it easier to release new crate, without having to ping anyone.

Whoever has the right to create a new release on GitHub shall have the right to publish it to crates.io

**NOTE that this new workflow requires a secret `CARGO_REGISTRY_TOKEN` to be set.
With scoped token, you can limit the token to only have the ability to publish new version under name `jobserver`, and nothing else.**