### PR TITLE
Drop msrv to 1.56

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,4 +107,4 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo hack check --lib --rust-version --ignore-private --locked
+      - run: cargo hack check --lib --rust-version --ignore-private --remove-dev-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 An implementation of the GNU Make jobserver for Rust.
 """
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.56"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.87"

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,12 +59,12 @@ impl std::fmt::Display for FromEnvError {
         match &self.inner {
             FromEnvErrorInner::NoEnvVar => write!(f, "there is no environment variable that describes jobserver to inherit"),
             FromEnvErrorInner::NoJobserver => write!(f, "there is no `--jobserver-fds=` or `--jobserver-auth=` in the environment variable"),
-            FromEnvErrorInner::CannotParse(s) => write!(f, "cannot parse jobserver environment variable value: {s}"),
-            FromEnvErrorInner::CannotOpenPath(s, err) => write!(f, "cannot open path or name {s} from the jobserver environment variable value: {err}"),
-            FromEnvErrorInner::CannotOpenFd(fd, err) => write!(f, "cannot open file descriptor {fd} from the jobserver environment variable value: {err}"),
-            FromEnvErrorInner::NegativeFd(fd) => write!(f, "file descriptor {fd} from the jobserver environment variable value is negative"),
-            FromEnvErrorInner::NotAPipe(fd, None) => write!(f, "file descriptor {fd} from the jobserver environment variable value is not a pipe"),
-            FromEnvErrorInner::NotAPipe(fd, Some(err)) => write!(f, "file descriptor {fd} from the jobserver environment variable value is not a pipe: {err}"),
+            FromEnvErrorInner::CannotParse(s) => write!(f, "cannot parse jobserver environment variable value: {}", s),
+            FromEnvErrorInner::CannotOpenPath(s, err) => write!(f, "cannot open path or name {} from the jobserver environment variable value: {}", s, err),
+            FromEnvErrorInner::CannotOpenFd(fd, err) => write!(f, "cannot open file descriptor {} from the jobserver environment variable value: {}", fd, err),
+            FromEnvErrorInner::NegativeFd(fd) => write!(f, "file descriptor {} from the jobserver environment variable value is negative", fd),
+            FromEnvErrorInner::NotAPipe(fd, None) => write!(f, "file descriptor {} from the jobserver environment variable value is not a pipe", fd),
+            FromEnvErrorInner::NotAPipe(fd, Some(err)) => write!(f, "file descriptor {} from the jobserver environment variable value is not a pipe: {}", fd, err),
             FromEnvErrorInner::Unsupported => write!(f, "jobserver inheritance is not supported on this platform"),
         }
     }


### PR DESCRIPTION
MSRV was bumped due to a dev dependency and tests, but dev dependencies and tests are not used by consumers of the library.

This drops MSRV back to the lowest value I could make work without having to hack around too much.

## Using `--remove-dev-deps` with `cargo hack`

Note that this does not affect consumers of this library and is only for local CI.

Note that `cargo hack` needs to use `--remove-dev-deps`. I'm not sure why exactly, but cargo 1.56 seems to misbehave when resolving the `tempfile` dev-dependency.

```
error: failed to select a version for the requirement `rustix = "=0.38.31"`
candidate versions found which didn't match: 0.38.9, 0.38.8, 0.38.7, ...
location searched: crates.io index
required by package `tempfile v3.10.1`
    ... which satisfies dependency `tempfile = "=3.10.1"` of package `jobserver v0.1.31 (D:\Repo\jobserver-rs)`
```

The rustix version *is* available, and I can't figure out why it doesn't think it's a candidate.