### PR TITLE
Bump libc to 0.2.171 to fix sigaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -394,14 +394,7 @@ pub(crate) fn spawn_helper(
     let mut err = None;
     USR1_INIT.call_once(|| unsafe {
         let mut new: libc::sigaction = mem::zeroed();
-        #[cfg(target_os = "aix")]
-        {
-            new.sa_union.__su_sigaction = sigusr1_handler;
-        }
-        #[cfg(not(target_os = "aix"))]
-        {
-            new.sa_sigaction = sigusr1_handler as usize;
-        }
+        new.sa_sigaction = sigusr1_handler as usize;
         new.sa_flags = libc::SA_SIGINFO as _;
         if libc::sigaction(libc::SIGUSR1, &new, ptr::null_mut()) != 0 {
             err = Some(io::Error::last_os_error());


### PR DESCRIPTION
Change to use `sa_sigaction` instead of `sa_union.__su_sigaction`, now that the libc crate 0.2.171 implementation for AIX defines `sa_sigaction` as a direct member of `struct sigaction`, aligning it with implementations on other similar platforms. (https://github.com/rust-lang/libc/pull/4250).