### PR TITLE
Use getrandom for randomness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 dependencies = [
+ "getrandom",
  "libc",
  "nix",
  "tempfile",
@@ -47,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"
@@ -68,6 +81,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rustix"
@@ -92,6 +111,15 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -159,3 +187,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ libc = "0.2.87"
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.28.0", features = ["fs"] }
 
+[target.'cfg(windows)'.dependencies]
+getrandom = { version = "0.3.2", features = ["std"] }
+
 [dev-dependencies]
 tempfile = "3.10.1"
 


### PR DESCRIPTION
The reason `getrandom` isn't currently used is given by: https://github.com/rust-lang/jobserver-rs/blob/f494d826e436a7027f40affa504cb8777923d108/src/windows.rs#L71-L76 which says `getrandom` can't be used due to https://github.com/rust-lang/rust/issues/65014 which was closed as an instance of https://github.com/rust-lang/cargo/issues/4866 which is closed in favour of a nightly cargo feature https://github.com/rust-lang/cargo/issues/7915 which has since been stabilised.

So I think we're good now.