### PR TITLE
Fix running inside miri when using in-process accounting

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -552,12 +552,7 @@ mod test {
 
     use crate::{test::run_named_fifo_try_acquire_tests, Client};
 
-    use std::{
-        fs::File,
-        io::{self, Write},
-        os::unix::io::AsRawFd,
-        sync::Arc,
-    };
+    use std::{fs::File, io::Write, os::unix::io::AsRawFd, sync::Arc};
 
     fn from_imp_client(imp: ClientImp) -> Client {
         Client {
@@ -611,7 +606,7 @@ mod test {
         #[cfg(not(target_os = "linux"))]
         assert_eq!(
             new_client_from_pipe().0.try_acquire().unwrap_err().kind(),
-            io::ErrorKind::Unsupported
+            std::io::ErrorKind::Unsupported
         );
 
         #[cfg(target_os = "linux")]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -74,7 +74,7 @@ impl Client {
 
         // Atomically-create-with-cloexec on Linux.
         #[cfg(target_os = "linux")]
-        if libc::syscall(libc::SYS_pipe2, pipes.as_mut_ptr(), libc::O_CLOEXEC) == -1 {
+        if libc::pipe2(pipes.as_mut_ptr(), libc::O_CLOEXEC) == -1 {
             return Err(io::Error::last_os_error());
         }
 


### PR DESCRIPTION
Miri doesn't currently support mkfifo, so can't present named pipes for other processes (but spawning processes isn't possible from miri anyway) And it also isn't possible in miri to get fd's inherited from the parent process. But this is enough for what running rustc in miri needs.

Fixes https://github.com/rust-lang/jobserver-rs/issues/108